### PR TITLE
Mod hack/fix_vra_swagger to deal with diff in return code for network-ip-range creation 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/go-openapi/swag v0.18.0
 	github.com/go-openapi/validate v0.18.0
 )
+
+go 1.13

--- a/hack/fix_vra_swagger
+++ b/hack/fix_vra_swagger
@@ -104,7 +104,7 @@ def add_region_enumerate_return_code(swagger):
 
 
 def add_network_ip_range_return_code(swagger):
-    path = '"/iaas/api/network-ip-ranges'
+    path = '/iaas/api/network-ip-ranges'
     responses = swagger['paths'][path]['post']['responses']
     responses['201'] = responses['202']
     

--- a/hack/fix_vra_swagger
+++ b/hack/fix_vra_swagger
@@ -103,6 +103,12 @@ def add_region_enumerate_return_code(swagger):
     responses['201'] = responses['200']
 
 
+def add_network_ip_range_return_code(swagger):
+    path = '"/iaas/api/network-ip-ranges'
+    responses = swagger['paths'][path]['post']['responses']
+    responses['201'] = responses['202']
+    
+
 def add_blockdevice_persistent(swagger):
     persistent = {
         "description": "Indicates whether the block device survives a delete action.",

--- a/hack/fix_vra_swagger
+++ b/hack/fix_vra_swagger
@@ -222,6 +222,7 @@ if __name__ == "__main__":
     change_response_model_to_request_tracker(swagger)
 
     add_region_enumerate_return_code(swagger)
+    add_network_ip_range_return_code(swagger)
 
     add_blockdevice_persistent(swagger)
     add_blockdevice_delete_purge(swagger)


### PR DESCRIPTION
Working on adding network ip range resource to terraform-provder-vra. Noticing that there's a difference in the return code specified in the swagger from https://www.mgmt.cloud.vmware.com/ (returns 202) and what I'm seeing with the on-prem 8.0.1.( returns 201)  This is similar to what we saw with #11. This adds 201 as a valid return code for the ip-range creation operation. 

@markpeek @dmettem  this also brings up the question of whether you want PRs to include the updated swagger, model and client  and just (in this case) the mods  to fix_vra_swagger or if we should run ```make swagger```  and include the updated files? 
