### PR TITLE
Add default value to sharedResources in ProjectSpecification

### DIFF
--- a/hack/fix_vra_swagger
+++ b/hack/fix_vra_swagger
@@ -261,6 +261,18 @@ def change_operationId_for_get_fabric_compute(swagger):
     fc['operationId'] = 'getFabricCompute'
 
 
+def add_default_value_to_sharedResources(swagger):
+    default_spec = {
+        "default": True
+    }
+
+    # Update ProjectSpecification -> sharedResources property with a default value of true.
+    attributes = swagger['definitions']['ProjectSpecification']['properties']['sharedResources']
+
+    if 'default' not in attributes.keys():
+        attributes['default'] = True
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--omit-security', action='store_false')
@@ -281,6 +293,8 @@ if __name__ == "__main__":
     add_blockdevice_resize(swagger)
     add_404_not_found(swagger)
     add_400_bad_request(swagger)
+
+    add_default_value_to_sharedResources(swagger)
 
     add_error_definition(swagger)
 

--- a/pkg/models/project_specification.go
+++ b/pkg/models/project_specification.go
@@ -42,7 +42,7 @@ type ProjectSpecification struct {
 	OperationTimeout int64 `json:"operationTimeout,omitempty"`
 
 	// Specifies whether the resources in this projects are shared or not. If not set default will be used.
-	SharedResources bool `json:"sharedResources,omitempty"`
+	SharedResources *bool `json:"sharedResources,omitempty"`
 
 	// List of viewer users associated with the project.
 	Viewers []*User `json:"viewers"`


### PR DESCRIPTION
Due to the issue in the client generated by swagger codegen, boolean properties
that are optional and set to false are omitted when sending the request to API
server. This change adds a default value to sharedResources property in
ProjectSpecification.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>