### PR TITLE
Add default to boolean properties in FabricNetworkVSphereSpecification

### DIFF
--- a/hack/fix_vra_swagger
+++ b/hack/fix_vra_swagger
@@ -272,16 +272,19 @@ def change_operationId_for_get_fabric_compute(swagger):
     fc['operationId'] = 'getFabricCompute'
 
 
-def add_default_value_to_sharedResources(swagger):
-    default_spec = {
-        "default": True
-    }
+def add_default_value_to_boolean_properties(swagger):
+    # Update following definition properties of type boolean with specified default value.
+    paths = [
+        ('FabricNetworkVsphereSpecification', 'isDefault', False),
+        ('FabricNetworkVsphereSpecification', 'isPublic', False),
+        ('ProjectSpecification', 'sharedResources', True),
+    ]
 
-    # Update ProjectSpecification -> sharedResources property with a default value of true.
-    attributes = swagger['definitions']['ProjectSpecification']['properties']['sharedResources']
-
-    if 'default' not in attributes.keys():
-        attributes['default'] = True
+    # Update the needed definitions
+    for (definition, propertyName, defaultValue) in paths:
+        attributes = swagger['definitions'][definition]['properties'][propertyName]
+        if 'default' not in attributes.keys():
+            attributes['default'] = defaultValue
 
 
 if __name__ == "__main__":
@@ -305,7 +308,7 @@ if __name__ == "__main__":
     add_404_not_found(swagger)
     add_400_bad_request(swagger)
 
-    add_default_value_to_sharedResources(swagger)
+    add_default_value_to_boolean_properties(swagger)
 
     add_error_definition(swagger)
 

--- a/pkg/models/fabric_network_vsphere_specification.go
+++ b/pkg/models/fabric_network_vsphere_specification.go
@@ -40,10 +40,10 @@ type FabricNetworkVsphereSpecification struct {
 	IPV6Cidr string `json:"ipv6Cidr,omitempty"`
 
 	// Indicates whether this is the default subnet for the zone.
-	IsDefault bool `json:"isDefault,omitempty"`
+	IsDefault *bool `json:"isDefault,omitempty"`
 
 	// Indicates whether the sub-network supports public IP assignment.
-	IsPublic bool `json:"isPublic,omitempty"`
+	IsPublic *bool `json:"isPublic,omitempty"`
 
 	// A set of tag keys and optional values that were set on this resource instance.
 	Tags []*Tag `json:"tags"`


### PR DESCRIPTION
Due to the issue in the client generated by swagger codegen, boolean
properties that are optional and set to false are omitted when sending
the request to API server. This change adds a default value to isDefault
and isPublic properties in FabricNetworkVSphereSpecificaiton.

Reported by @cars and helps to implement importable only 
[fabric_network_vsphere](https://github.com/vmware/terraform-provider-vra/issues/224) resource.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>