### PR TITLE
Correct the IaaS swagger fix in the last commit

### DIFF
--- a/hack/fix_vra_swagger
+++ b/hack/fix_vra_swagger
@@ -68,7 +68,7 @@ def change_response_model(swagger):
     paths = [
         ('/iaas/api/machines/{id}/disks', 'post', '200', '#/definitions/RequestTracker'),
         ('/iaas/api/machines/{id}/disks/{id1}', 'delete', '202', '#/definitions/RequestTracker'),
-        ('/iaas/api/block-devices/{id}/snapshots/{id1}', 'get', '200', '#/definitions/Snapshot'),
+        ('/iaas/api/block-devices/{id}/snapshots/{id1}', 'get', '200', '#/definitions/DiskSnapshot'),
     ]
 
     # Update the needed paths

--- a/pkg/client/disk/get_disk_snapshot_responses.go
+++ b/pkg/client/disk/get_disk_snapshot_responses.go
@@ -58,20 +58,20 @@ func NewGetDiskSnapshotOK() *GetDiskSnapshotOK {
 successful operation
 */
 type GetDiskSnapshotOK struct {
-	Payload *models.Snapshot
+	Payload *models.DiskSnapshot
 }
 
 func (o *GetDiskSnapshotOK) Error() string {
 	return fmt.Sprintf("[GET /iaas/api/block-devices/{id}/snapshots/{id1}][%d] getDiskSnapshotOK  %+v", 200, o.Payload)
 }
 
-func (o *GetDiskSnapshotOK) GetPayload() *models.Snapshot {
+func (o *GetDiskSnapshotOK) GetPayload() *models.DiskSnapshot {
 	return o.Payload
 }
 
 func (o *GetDiskSnapshotOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Snapshot)
+	o.Payload = new(models.DiskSnapshot)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {


### PR DESCRIPTION
Last commit had a swagger fix to change the response model for
/iaas/api/block-devices/{id}/snapshots/{id} to Snapshot, but it
should be DiskSnapshot, which includes the property
that is not available in Snapshot.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>